### PR TITLE
Fix link to Twitter profile

### DIFF
--- a/components/Welcome.js
+++ b/components/Welcome.js
@@ -29,7 +29,7 @@ export default function Welcome() {
           projects whilst self-teaching software development and design.
           Occasionally, I write essays on calm life, exploration, experiments
           and making sense of the world. My{" "}
-          <a href="https://twitter.com/sokirill"> DMs</a> are always open.
+          <a href="https://twitter.com/kirso_"> DMs</a> are always open.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Hey! The link to your Twitter profile (in home page) seems broken.

| Home page | Twitter |
|--------|-------|
| <img width=600 src=https://user-images.githubusercontent.com/7823011/197147340-4e0a9e74-9e1f-43ed-9ae7-887d33736c1c.png />       |     <img width=600 src=https://user-images.githubusercontent.com/7823011/197147536-040ae7c9-b0fd-4441-b297-ece3515d9a5d.png />  |

I updated the link to https://twitter.com/kirso_ and it seems to work:

<img width=400 src=https://user-images.githubusercontent.com/7823011/197148114-718ca262-86ea-4f10-8789-8a28322651a4.png />